### PR TITLE
Add support for Wagtail@2.2.2

### DIFF
--- a/wagtailcsvimport/templates/wagtailcsvimport/export_to_file.html
+++ b/wagtailcsvimport/templates/wagtailcsvimport/export_to_file.html
@@ -22,4 +22,5 @@
 {% block extra_js %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
+    {{ form.media.js }}
 {% endblock %}

--- a/wagtailcsvimport/templates/wagtailcsvimport/import_from_file.html
+++ b/wagtailcsvimport/templates/wagtailcsvimport/import_from_file.html
@@ -22,4 +22,5 @@
 {% block extra_js %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
+    {{ form.media.js }}
 {% endblock %}


### PR DESCRIPTION
Wagtaill v2.2.2 removed a lot of clutter from templates and moved them to the `Media` class in forms/widgets. This PR adds support for that version.

Commit with the "regression": https://github.com/wagtail/wagtail/commit/fe99aca27b2537ab92b86a3006fe5ce7cb781f56#diff-3c87c9d60deca4265e87fc74574e7251

Send me a Slack message if you want to discuss a bit about the project being blocked by this (and not in this public PR).