### PR TITLE
Prevent DB queries on init

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,4 @@ recreated. Follow this procedure:
 1. Make your changes to *tests/models.py*.
 1. Delete *tests/migrations/0001_initial.py*. There is no need to add
    more migrations, as they are only run on the transient test DB.
-1. Comment off the `wagtailcsvimport` entry in *tests/settings.py*.
-1. Run `python -m django makemigrations tests` from the project root.
-1. Revert the change to the *settings.py*.
+1. Run `DJANGO_SETTINGS_MODULE=tests.settings python -m django makemigrations tests` from the project root.

--- a/wagtailcsvimport/exporting.py
+++ b/wagtailcsvimport/exporting.py
@@ -19,7 +19,7 @@ BASE_FIELDS = ['id', 'type', 'parent', 'title', 'slug', 'full_url',
 FIELDS_TO_IGNORE = {'page_ptr'}
 
 
-def calculate_fields_for_model(page_model):
+def get_exportable_fields_for_model(page_model):
     # always include Wagtail Page fields
     fields = BASE_FIELDS[:]
     # then include the page subclass' fields that are:
@@ -36,12 +36,6 @@ def calculate_fields_for_model(page_model):
     specific_fields.sort()
     fields.extend(specific_fields)
     return fields
-
-
-# This will contain a list of which fields to export for all available
-# page models. It's calculated at initialization because the page
-# models won't change at runtime.
-EXPORT_FIELDS_FOR_MODEL = {m: calculate_fields_for_model(m) for m in get_page_models()}
 
 
 class Echo:
@@ -94,7 +88,7 @@ def export_pages(root_page, content_type=None, fieldnames=None,
 
     if fieldnames is None:
         # default to all exportable fields for the given model
-        fieldnames = EXPORT_FIELDS_FOR_MODEL[page_model]
+        fieldnames = get_exportable_fields_for_model(page_model)
 
     csv_writer = csv.DictWriter(pseudo_buffer, fieldnames=fieldnames)
     header = dict(zip(fieldnames, fieldnames))

--- a/wagtailcsvimport/exporting.py
+++ b/wagtailcsvimport/exporting.py
@@ -1,4 +1,5 @@
 import csv
+from functools import lru_cache
 import logging
 
 try:
@@ -19,6 +20,7 @@ BASE_FIELDS = ['id', 'type', 'parent', 'title', 'slug', 'full_url',
 FIELDS_TO_IGNORE = {'page_ptr'}
 
 
+@lru_cache(64)
 def get_exportable_fields_for_model(page_model):
     # always include Wagtail Page fields
     fields = BASE_FIELDS[:]

--- a/wagtailcsvimport/forms.py
+++ b/wagtailcsvimport/forms.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import ugettext_lazy as _
@@ -80,6 +82,7 @@ class ExportForm(forms.Form):
         self.fields['fields'].initial = [c[0] for c in page_fields_choices]
 
     @staticmethod
+    @lru_cache(64)
     def get_export_fields_choices(page_model):
         choices = []
         if page_model is None:

--- a/wagtailcsvimport/forms.py
+++ b/wagtailcsvimport/forms.py
@@ -12,41 +12,22 @@ except ImportError:  # fallback for Wagtail <2.0
     from wagtail.wagtailcore.models import Page
 
 
-from .exporting import EXPORT_FIELDS_FOR_MODEL
-
-
-def calculate_export_fields_choices(page_model):
-    choices = []
-    if page_model is None:
-        page_model = Page
-    exportable_fields = EXPORT_FIELDS_FOR_MODEL[page_model]
-    for field_name in exportable_fields:
-        if field_name == 'full_url':
-            choices.append(('full_url', 'URL'))
-        elif field_name == 'parent':
-            choices.append(('parent', 'Parent page id'))
-        elif field_name == 'type':
-            choices.append(('type', 'Page type'))
-        else:
-            field = page_model._meta.get_field(field_name)
-            choices.append((field_name, field.verbose_name))
-    return choices
-
-
-DEFAULT_FIELDS_TO_EXPORT = calculate_export_fields_choices(Page)
-
-PAGE_TYPE_CHOICES = [
-    (ContentType.objects.get_for_model(p).id, p.get_verbose_name()) for p in get_page_models()
-]
+from .exporting import get_exportable_fields_for_model
 
 
 class PageTypeForm(forms.Form):
     page_type = forms.ChoiceField(
-        choices=PAGE_TYPE_CHOICES,
+        choices=[],  # populated on __init__
         required=False,
         label=_("Page type"),
         help_text=_("Will only export pages of this type, with all their extra information. If not set will export all pages of all types, but with minimal information.")
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        page_type_choices = [(ContentType.objects.get_for_model(p).id, p.get_verbose_name()) for p in get_page_models()]
+        self.fields['page_type'].choices = page_type_choices
+        self.fields['page_type'].initial = ContentType.objects.get_for_model(Page)
 
     def get_content_type(self):
         assert(not self._errors)  # must be called after is_valid()
@@ -75,8 +56,7 @@ class ImportFromFileForm(forms.Form):
 class ExportForm(forms.Form):
     fields = forms.MultipleChoiceField(
         label=_('Fields to export'),
-        choices=DEFAULT_FIELDS_TO_EXPORT,
-        initial=[choice[0] for choice in DEFAULT_FIELDS_TO_EXPORT],
+        choices=[],
         widget=forms.CheckboxSelectMultiple)
     only_published = forms.BooleanField(
         label=_('Include only published pages?'),
@@ -92,5 +72,27 @@ class ExportForm(forms.Form):
     def __init__(self, *args, **kwargs):
         page_model = kwargs.pop('page_model', None)
         super().__init__(*args, **kwargs)
-        if page_model is not None:
-            self.fields['fields'].choices = calculate_export_fields_choices(page_model)
+        page_fields_choices = self.get_export_fields_choices(Page)
+        if page_model is None:
+            self.fields['fields'].choices = page_fields_choices
+        else:
+            self.fields['fields'].choices = self.get_export_fields_choices(page_model)
+        self.fields['fields'].initial = [c[0] for c in page_fields_choices]
+
+    @staticmethod
+    def get_export_fields_choices(page_model):
+        choices = []
+        if page_model is None:
+            page_model = Page
+        exportable_fields = get_exportable_fields_for_model(page_model)
+        for field_name in exportable_fields:
+            if field_name == 'full_url':
+                choices.append(('full_url', 'URL'))
+            elif field_name == 'parent':
+                choices.append(('parent', 'Parent page id'))
+            elif field_name == 'type':
+                choices.append(('type', 'Page type'))
+            else:
+                field = page_model._meta.get_field(field_name)
+                choices.append((field_name, field.verbose_name))
+        return choices


### PR DESCRIPTION
This causes all sorts of problems to apps using the library, as sometimes the DB is not available when the module is being initialized.

A nice side effect is that now it's possible to create migrations for the *tests* app without having to uncomment *wagtailcsvimport* from *tests/settings.py*.

Also this introduces simple caching of functions that calculate data based solely on model classes. It's a safe and easy way to improve performance a bit.