### PR TITLE
Allow addition of non-page models like snippets and django models

### DIFF
--- a/wagtailcsvimport/forms.py
+++ b/wagtailcsvimport/forms.py
@@ -2,6 +2,7 @@ from functools import lru_cache
 
 from django import forms
 from django.forms import Media
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import ugettext_lazy as _
 
@@ -16,6 +17,13 @@ except ImportError:  # fallback for Wagtail <2.0
 
 
 from .exporting import get_exportable_fields_for_model
+from django.apps import apps
+
+
+def get_models():
+    page_models = get_page_models()
+    settings_models = [apps.get_model(x) for x in settings.WAGTAILCSVIMPORT_MODELS]
+    return [*page_models, *settings_models]
 
 
 class PageTypeForm(forms.Form):
@@ -34,7 +42,7 @@ class PageTypeForm(forms.Form):
     @staticmethod
     def get_page_type_choices():
         choices = []
-        for m in get_page_models():
+        for m in get_models():
             choice = (ContentType.objects.get_for_model(m).id, m.get_verbose_name())
             if m is Page:
                 page_choice = choice

--- a/wagtailcsvimport/wagtail_hooks.py
+++ b/wagtailcsvimport/wagtail_hooks.py
@@ -33,13 +33,13 @@ class CsvImportMenuItem(MenuItem):
 
 @hooks.register('register_admin_menu_item')
 def register__import_menu_item():
-    return CsvImportMenuItem(
+    return MenuItem(
         _('CSV Export'), reverse('wagtailcsvimport:export_to_file'), classnames='icon icon-collapse-down', order=898
     )
 
 
 @hooks.register('register_admin_menu_item')
 def register__import_menu_item():
-    return CsvImportMenuItem(
+    return MenuItem(
         _('CSV Import'), reverse('wagtailcsvimport:import_from_file'), classnames='icon icon-collapse-up', order=899
     )


### PR DESCRIPTION
This pull request refactors and enhances the `wagtailcsvimport` app by improving code modularity, adding configurability, and addressing compatibility issues. The most significant changes include introducing helper functions for reusability, supporting custom models via settings, and replacing a custom menu item class with a standard one.

### Code modularity and reusability:
* Created a new `get_content_type` helper function to replace the inline lambda for retrieving a page's content type, improving readability and reusability in `wagtailcsvimport/exporting.py`.
* Updated the `export_pages` function to handle cases where the `descendant_of` method is unavailable, ensuring broader compatibility with different page models.

### Configurability:
* Added a `get_models` function in `wagtailcsvimport/forms.py` to combine page models and additional models specified in the `WAGTAILCSVIMPORT_MODELS` setting, enabling custom model support.
* Modified the `PageTypeForm` class to use the `get_models` function instead of `get_page_models`, allowing the form to include custom models in its choices.

### Code simplification:
* Replaced the custom `CsvImportMenuItem` class with the standard `MenuItem` class for registering admin menu items in `wagtailcsvimport/wagtail_hooks.py`, simplifying the codebase.